### PR TITLE
Add type null for parsing

### DIFF
--- a/examples/test NULL type/test NULL type.ino
+++ b/examples/test NULL type/test NULL type.ino
@@ -1,0 +1,34 @@
+#include <Arduino.h>
+#include <GSON.h>
+
+char json[] = R"raw({"key":"value","int":12345,"nullType":null,"obj":{"float":3.14,"bool":false},"arr":["hello",true]})raw";
+
+void setup() {
+    Serial.begin(115200);
+    while( !Serial ){
+        delay(100);
+    }
+    Serial.println();
+
+    gson::Parser p;
+    p.parse(json);
+
+    Serial.println("==== CHUNKS ====");
+    for (int i = 0; i < p.length(); i++) {
+        Serial.print(i);
+        Serial.print(". [");
+        Serial.print(p.readType(i));
+        Serial.print("] ");
+        Serial.print(p.key(i));
+        Serial.print(":");
+        Serial.print(p.value(i));
+        Serial.print(" {");
+        Serial.print(p.parent(i));
+        Serial.println("}");
+    }
+    Serial.println();
+
+}
+
+void loop() {
+}

--- a/library.properties
+++ b/library.properties
@@ -1,10 +1,10 @@
 name=GSON
-version=1.5.12
+version=1.5.11
 author=AlexGyver <alex@alexgyver.ru>
 maintainer=AlexGyver <alex@alexgyver.ru>
 sentence=Light JSON parsing and assembling library for Arduino
 paragraph=Light JSON parsing and assembling library for Arduino
 category=Data Processing
-url=https://github.com/SergeyF11/GSON
+url=https://github.com/GyverLibs/GSON
 architectures=*
 depends=StringUtils,GTL

--- a/library.properties
+++ b/library.properties
@@ -1,10 +1,10 @@
 name=GSON
-version=1.5.11
+version=1.5.11n
 author=AlexGyver <alex@alexgyver.ru>
 maintainer=AlexGyver <alex@alexgyver.ru>
 sentence=Light JSON parsing and assembling library for Arduino
 paragraph=Light JSON parsing and assembling library for Arduino
 category=Data Processing
-url=https://github.com/GyverLibs/GSON
+url=https://github.com/SergeyF11/GSON
 architectures=*
 depends=StringUtils,GTL

--- a/library.properties
+++ b/library.properties
@@ -1,5 +1,5 @@
 name=GSON
-version=1.5.11n
+version=1.5.12
 author=AlexGyver <alex@alexgyver.ru>
 maintainer=AlexGyver <alex@alexgyver.ru>
 sentence=Light JSON parsing and assembling library for Arduino

--- a/src/utils/entry.h
+++ b/src/utils/entry.h
@@ -222,6 +222,9 @@ class Entry : public Text {
             case gson::Type::Bool:
                 p.print((ens->valueText(idx)[0] == 't') ? F("true") : F("false"));
                 break;
+            case gson::Type::Null:
+                p.print(F("null"));
+                break;
             default:
                 break;
         }

--- a/src/utils/parser.h
+++ b/src/utils/parser.h
@@ -422,6 +422,9 @@ class Parser {
                         case '0' ... '9':
                             ebuf.type = gson::Type::Int;
                             break;
+                        case 'n':
+                            ebuf.type = gson::Type::Null;
+                            break;
                         default:
                             return gson::Error::UnknownToken;
                     }

--- a/src/utils/parser.h
+++ b/src/utils/parser.h
@@ -174,6 +174,8 @@ class Parser {
                 return F("Float");
             case gson::Type::Bool:
                 return F("Bool");
+            case gson::Type::Null:
+                return F("Null");                 
             default:
                 return F("None");
         }

--- a/src/utils/parser.h
+++ b/src/utils/parser.h
@@ -455,6 +455,11 @@ class Parser {
                             return gson::Error::BrokenToken;
                         }
                     }
+                    if (ebuf.is(gson::Type::Null)) {
+                        if (!(ebuf.val_len == 4 && !strncmp_P(ebuf.value(ents.str), PSTR("null"), 4))){
+                            return gson::Error::BrokenToken;
+                        }
+                    }
                     if (length() == GSON_MAX_INDEX - 1) return gson::Error::IndexOverflow;
                     ebuf.parent = parent;
                     if (!ents.push(ebuf)) return gson::Error::Alloc;

--- a/src/utils/types.h
+++ b/src/utils/types.h
@@ -11,6 +11,7 @@ enum class Type : uint8_t {
     Int,
     Float,
     Bool,
+    Null,
 };
 
 enum class Error : uint8_t {


### PR DESCRIPTION
Добавил JSON тип null для парсера. Иначе парсер прекращал разбор данных с ошибкой "Неизвестный тип" и все ключи после ключа с этим типом были недоступны для использования. 